### PR TITLE
Add license to gemspec

### DIFF
--- a/wkhtmltopdf-binary-edge.gemspec
+++ b/wkhtmltopdf-binary-edge.gemspec
@@ -20,4 +20,6 @@ Gem::Specification.new do |s|
     libexec/wkhtmltopdf-darwin-x86_64
     libexec/wkhtmltopdf-linux-amd64
     libexec/wkhtmltopdf-linux-x86)
+  
+  s.licenses = ['MIT']
 end


### PR DESCRIPTION
Right now license_finder gives an unknown:

```
wkhtmltopdf-binary-edge, 0.12.3.0, unknown
```