### PR TITLE
Add powerpc64le binary - 0.12.4

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 arch = case RUBY_PLATFORM
+  when /powerpc64le-linux/
+    'linux-powerpc64le'
   when /64.*linux/
     'linux-amd64'
   when /linux/


### PR DESCRIPTION
Compiled from sources with qt patches and [this segmentation fault prevention fix](https://www.ibm.com/developerworks/community/forums/html/topic?id=94177684-c459-4d4a-b689-8201deac74a0) using
```bash
$ python2.7 scripts/build.py posix-local
```
Binary version:
```bash
$ ./wkhtmltopdf -V
wkhtmltopdf 0.12.4 (with patched qt)
```
Build machine details:
```bash
$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 16.04 LTS
Release:        16.04
Codename:       xenial
$ uname -a
Linux test-ibm2 4.4.0-21-generic #37-Ubuntu SMP Mon Apr 18 18:30:22 UTC 2016 ppc64le ppc64le ppc64le GNU/Linux
```