### PR TITLE
Fix the handling of single quotes in the wrapper script

### DIFF
--- a/bin/wkhtmltopdf
+++ b/bin/wkhtmltopdf
@@ -9,7 +9,6 @@ arch = case RUBY_PLATFORM
     raise "Invalid platform. Must be running linux or intel-based Mac OS."
 end
 
-args = $*.map { |x| x.include?(' ') ? "'" + x + "'" : x }
 cmd = File.expand_path "#{File.dirname(__FILE__)}/../libexec/wkhtmltopdf-#{arch}"
 
-exec "#{cmd} #{args.join(' ')}"
+exec cmd, *ARGV


### PR DESCRIPTION
There's a flaw in how bin/wkhtmltopdf handles single quotes.

```shell-session
% bin/wkhtmltopdf --title "User's Guide" file:///path/to/html /tmp/output.pdf
sh: -c: line 0: unexpected EOF while looking for matching `''
sh: -c: line 1: syntax error: unexpected end of file
```

This can lead to security vulnerability when the user of this package passes an untrusted string to the bin/wkhtmltopdf command.